### PR TITLE
Not remove fedora-release file

### DIFF
--- a/updater.sh
+++ b/updater.sh
@@ -23,4 +23,4 @@ repos="
   | sort \
   | uniq \
   | sed '/langpack-/{/langpack-en/!d};/all-langpacks/d' \
-  | sed '/^fedora-release-/{/^fedora-release-common/!{/^fedora-release-identity-basic/!{/^fedora-release-[0-9]\{1,\}/!d}}}' | tee rpms.lock
+  | sed '/^fedora-release-/{/^fedora-release-\(common\|identity-basic\|[0-9]\{1,\}\)/!d}' | tee rpms.lock


### PR DESCRIPTION
dbus.serviceをloadするのに必要なfedora-release-fileが含まれないことを修正する。
この3つが必要(verは今のやつなので関係ない）
```
fedora-release-33-4
fedora-release-common-33-4
fedora-release-identity-basic-33-4
```
