### PR TITLE
Use official metalink as dnf repository

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,22 +19,6 @@ jobs:
       MAKE: make FEDORA_VERSION=${{ matrix.fedora }}
     runs-on: ubuntu-latest
     steps:
-      - name: Select mirror
-        run: |
-          for url in \
-            https://mirror.genesisadaptive.com/fedora/linux \
-            http://mirror.math.princeton.edu/pub/fedora/linux
-          do
-            echo "Trying ${url}"
-            if (curl --fail -L --connect-timeout 5 ${url} > /dev/null 2> /dev/null)
-            then
-              echo "FEDORA_MIRROR=${url}" >> ${GITHUB_ENV}
-              exit 0
-            fi
-          done
-          echo "No mirror is available"
-          false
-
       - name: Checkout repository
         uses: actions/checkout@v2
 
@@ -42,9 +26,9 @@ jobs:
         run: echo "FEDORA_MAJOR=$(${MAKE} show-fedora-major)" >> ${GITHUB_ENV}
 
       - name: Build builder image
-        run: ${MAKE} builder FEDORA_MIRROR=${FEDORA_MIRROR}
+        run: ${MAKE} builder
       - name: Build updater image
-        run: ${MAKE} updater FEDORA_MIRROR=${FEDORA_MIRROR}
+        run: ${MAKE} updater
 
       - name: Login to GitHub Container Registry
         if: github.event_name == 'push'

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,24 +15,26 @@ RUN --mount=type=cache,target=/var/cache/dnf \
     pykickstart \
     wget \
   && dnf clean all \
+  && rm /etc/yum.repos.d/*.repo \
   && dnf config-manager \
     --add-repo https://download.docker.com/linux/fedora/docker-ce.repo
+
+COPY fedora.repo /etc/yum.repos.d/
 
 WORKDIR /work
 
 RUN curl --fail https://getfedora.org/static/fedora.gpg | gpg --import
 
-ARG FEDORA_MIRROR=https://dl.fedoraproject.org/pub/fedora/linux
+ARG FEDORA_ISO_MIRROR=https://dl.fedoraproject.org/pub/fedora/linux
 ARG FEDORA_VERSION
 ARG FEDORA_MAJOR
 ENV FEDORA_VERSION=${FEDORA_VERSION} \
-  FEDORA_MIRROR=${FEDORA_MIRROR} \
   FEDORA_MAJOR=${FEDORA_MAJOR}
 RUN curl --fail -L --remote-name \
-    ${FEDORA_MIRROR}/releases/${FEDORA_MAJOR}/Server/x86_64/iso/Fedora-Server-${FEDORA_VERSION}-x86_64-CHECKSUM \
+    ${FEDORA_ISO_MIRROR}/releases/${FEDORA_MAJOR}/Server/x86_64/iso/Fedora-Server-${FEDORA_VERSION}-x86_64-CHECKSUM \
   && isofile=Fedora-Server-netinst-x86_64-${FEDORA_VERSION}.iso \
   && curl --fail -L --remote-name \
-    ${FEDORA_MIRROR}/releases/${FEDORA_MAJOR}/Server/x86_64/iso/${isofile} \
+    ${FEDORA_ISO_MIRROR}/releases/${FEDORA_MAJOR}/Server/x86_64/iso/${isofile} \
   && gpg --verify *-CHECKSUM \
   && sha256sum --ignore-missing -c *-CHECKSUM \
   && mkdir ./iso-root \

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,10 @@
 SHELL := /bin/bash
 
-FEDORA_VERSION ?= 33-1.2
+FEDORA_VERSION ?= 35-1.2
 FEDORA_MAJOR   := $(shell echo $(FEDORA_VERSION) | cut -f1 -d-)
 
 ifeq ($(shell cat /etc/timezone),Asia/Tokyo)
-FEDORA_MIRROR := https://ftp.yz.yamagata-u.ac.jp/pub/linux/fedora-projects/fedora/linux
-else
-FEDORA_MIRROR := https://dl.fedoraproject.org/pub/fedora/linux
+BUILD_OPTS := --build-arg FEDORA_ISO_MIRROR=https://ftp.yz.yamagata-u.ac.jp/pub/linux/fedora-projects/fedora/linux
 endif
 
 BUILDER_IMAGE := tmprootfs-fedora-builder:$(FEDORA_MAJOR)
@@ -17,9 +15,9 @@ export DOCKER_BUILDKIT = 1
 .PHONY: builder
 builder:
 	docker build \
+		$(BUILD_OPTS) \
 		--build-arg FEDORA_VERSION=$(FEDORA_VERSION) \
 		--build-arg FEDORA_MAJOR=$(FEDORA_MAJOR) \
-		--build-arg FEDORA_MIRROR=$(FEDORA_MIRROR) \
 		-t $(BUILDER_IMAGE) \
 		.
 
@@ -28,7 +26,6 @@ updater:
 	docker build \
 		-f updater.Dockerfile \
 		--build-arg FEDORA_MAJOR=$(FEDORA_MAJOR) \
-		--build-arg FEDORA_MIRROR=$(FEDORA_MIRROR) \
 		-t $(UPDATER_IMAGE) \
 		.
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -25,19 +25,9 @@ then
 fi
 
 
-dnf_repos="
-	--repofrompath releases-tmp,${FEDORA_MIRROR}/releases/${FEDORA_MAJOR}/Everything/x86_64/os
-	--repofrompath updates-tmp,${FEDORA_MIRROR}/updates/${FEDORA_MAJOR}/Everything/x86_64
-	--repo releases-tmp
-	--repo updates-tmp
-	--repo docker-ce-stable
-"
-
-
 # Download rpms
 mkdir -p downloads
 cat rpms.lock | xargs -n256 dnf download \
-  ${dnf_repos} \
   --arch=x86_64 --arch=noarch \
   --downloaddir=downloads
 while read package

--- a/fedora.repo
+++ b/fedora.repo
@@ -1,0 +1,23 @@
+[fedora]
+name=Fedora $releasever - $basearch
+metalink=https://mirrors.fedoraproject.org/metalink?repo=fedora-$releasever&arch=$basearch
+enabled=1
+countme=1
+metadata_expire=7d
+repo_gpgcheck=0
+type=rpm
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch
+fastestmirror=true
+
+[updates]
+name=Fedora $releasever - $basearch - Updates
+metalink=https://mirrors.fedoraproject.org/metalink?repo=updates-released-f$releasever&arch=$basearch
+enabled=1
+countme=1
+repo_gpgcheck=0
+type=rpm
+gpgcheck=1
+metadata_expire=6h
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch
+fastestmirror=true

--- a/updater.Dockerfile
+++ b/updater.Dockerfile
@@ -9,15 +9,17 @@ RUN --mount=type=cache,target=/var/cache/dnf \
     findutils \
     make \
   && dnf clean all \
+  && rm /etc/yum.repos.d/*.repo \
   && dnf config-manager \
     --add-repo https://download.docker.com/linux/fedora/docker-ce.repo
 
+COPY fedora.repo /etc/yum.repos.d/
+RUN sed '/fastestmirror=/d' -i /etc/yum.repos.d/fedora.repo
+
 VOLUME /var/cache/dnf
 
-ARG FEDORA_MIRROR=https://ftp.yz.yamagata-u.ac.jp/pub/linux/fedora-projects/fedora/linux
 ARG FEDORA_MAJOR
-ENV FEDORA_MAJOR=${FEDORA_MAJOR} \
-  FEDORA_MIRROR=${FEDORA_MIRROR}
+ENV FEDORA_MAJOR=${FEDORA_MAJOR}
 
 VOLUME /work
 WORKDIR /work

--- a/updater.sh
+++ b/updater.sh
@@ -1,21 +1,11 @@
 #!/bin/bash
 
-repos="
-  --repofrompath releases-tmp,${FEDORA_MIRROR}/releases/${FEDORA_MAJOR}/Everything/x86_64/os
-  --repofrompath updates-tmp,${FEDORA_MIRROR}/updates/${FEDORA_MAJOR}/Everything/x86_64
-  --repo releases-tmp
-  --repo updates-tmp
-  --repo docker-ce-stable
-"
-
 (
   dnf repoquery \
-    ${repos} \
     --arch=x86_64 --arch=noarch \
     --nvr --latest-limit=1 \
     $(cat packages.list)
   dnf repoquery \
-    ${repos} \
     --arch=x86_64 --arch=noarch \
     --nvr --resolve --requires --recursive \
     $(cat packages.list)


### PR DESCRIPTION
- avoid problem due to mirror sync delay on version lock
- automatically detect fastest mirror on build