### PR TITLE
Remove default dependencies from setup-sysroot.service

### DIFF
--- a/root/usr/lib/dracut/modules.d/96tmpfsroot/tmpfsroot-generator.sh
+++ b/root/usr/lib/dracut/modules.d/96tmpfsroot/tmpfsroot-generator.sh
@@ -37,6 +37,7 @@ EOS
 
 cat <<EOS > "$GENERATOR_DIR"/setup-sysroot.service
 [Unit]
+DefaultDependencies=no
 Before=initrd-root-fs.target
 After=sysroot.mount
 


### PR DESCRIPTION
Default dependency added `Requires=sysinit.target` `After=basic.target` and caused wrong start order of many targets.

## main branch
![image](https://user-images.githubusercontent.com/8390204/163302651-1a45ad16-b08f-4ca3-a886-ccd5126e0e8e.png)
## this PR
![image](https://user-images.githubusercontent.com/8390204/163302676-f1cada0f-4773-4581-a4c6-80b5a0e826de.png)
