### PR TITLE
Move grubenv to /boot/efi/EFI/fedora

### DIFF
--- a/ks.tpl.cfg
+++ b/ks.tpl.cfg
@@ -158,8 +158,8 @@ echo "GRUB_DISK_UUID0=64eb4db5-3385-46a5-a3d5-c48197a53555" >> /etc/default/grub
 echo "GRUB_DISK_UUID1=d2ada949-7fff-4257-91e9-793b25b0df02" >> /etc/default/grub
 grub2-mkconfig > /boot/efi/EFI/fedora/grub.cfg
 
-test ! -h /boot/grub2/grubenv && \
-  mv /boot/grub2/grubenv /boot/efi/EFI/fedora/
+test ! -h /boot/grub2/grubenv \
+  && mv /boot/grub2/grubenv /boot/efi/EFI/fedora/
 
 dracut -v --xz --no-hostonly --force /boot/initramfs-${kernel_version}.img ${kernel_version}
 ln -vs /boot/initramfs-${kernel_version}.img /boot/initramfs.img


### PR DESCRIPTION
fedora35からgrubenvの実態が/boot/efi/EFI/fedora以下から/boot/grub2/以下に移動していた。fedora34まで/boot/grub2/grubenvはsymlinkで実態は/boot/efi/EFI/fedora/grubenvだったけど変わったみたい