### PR TITLE
Remove Fedora 33 build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,6 @@ jobs:
     strategy:
       matrix:
         fedora:
-          - 33-1.2
           - 34-1.2
           - 35-1.2
           - 36-1.5


### PR DESCRIPTION
主要なミラーからisoが消えたっぽいのでbuilder imageの更新を止める