### PR TITLE
Override installfs by product.img

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -192,13 +192,10 @@ then
 fi
 
 
-# Copy custom files to install.img
+# Copy custom files to product.img
 if [ -d installfs.override ]
 then
-  mkdir -p /tmp/installfs
-  unsquashfs -d /tmp/installfs iso-root/images/install.img
-  cp -r installfs.override/* /tmp/installfs/
-  mksquashfs /tmp/installfs iso-root/images/install.img -noappend -comp xz -Xbcj x86
+  mksquashfs installfs.override iso-root/images/product.img -noappend -comp xz -Xbcj x86
 fi
 
 


### PR DESCRIPTION
別imgを作る方が早くて、build時に `--privileged` がいらなくなる (`install.img` を展開するとSELinuxのメタデータを展開することになって権限が必要だった)