### PR TITLE
Fix src rpm detection for installed packages

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -89,7 +89,8 @@ while read package; do
 
   pkg_src=$(
     dnf info ${pkg_name} \
-      | sed -n 's/^Source\s*:\s*\(\S\+\).src.rpm/\1/pq'
+      | sed -n 's/^Source\s*:\s*\(\S\+\).src.rpm/\1/p' \
+      | head -n1
   )
   src_fields=$(split_package_name ${pkg_src})
   src_name=$(echo ${src_fields} | cut -f1 -d" ")


### PR DESCRIPTION
Packages installed to builder image failed on src rpm detection.
```
Downloading curl-7.82.0-5.fc36 from kojipkgs
Error: No matching Packages to list
/entrypoint.sh: line 56: $1: unbound variable
- failed to download https://kojipkgs.fedoraproject.org/packages//7.82.0/5.fc36/x86_64/curl-7.82.0-5.fc36.x86_64.rpm
- failed to download https://kojipkgs.fedoraproject.org/packages//7.82.0/5.fc36/noarch/curl-7.82.0-5.fc36.noarch.rpm
Error: Package curl-7.82.0-5.fc36 unavailable
```
```
sh-5.2# dnf info --available curl
Error: No matching Packages to list

sh-5.2# dnf info curl
Last metadata expiration check: 0:01:25 ago on Fri Mar 31 06:34:33 2023.
Installed Packages
Name         : curl
Version      : 7.82.0
Release      : 13.fc36
Architecture : x86_64
Size         : 684 k
Source       : curl-7.82.0-13.fc36.src.rpm
Repository   : @System
From repo    : koji-override-1
Summary      : A utility for getting files from remote servers (FTP, HTTP, and others)
URL          : https://curl.se/
License      : MIT
Description  : curl is a command line tool for transferring data with URL syntax, supporting
             : FTP, FTPS, HTTP, HTTPS, SCP, SFTP, TFTP, TELNET, DICT, LDAP, LDAPS, FILE, IMAP,
             : SMTP, POP3 and RTSP.  curl supports SSL certificates, HTTP POST, HTTP PUT, FTP
             : uploading, HTTP form based upload, proxies, cookies, user+password
             : authentication (Basic, Digest, NTLM, Negotiate, kerberos...), file transfer
             : resume, proxy tunneling and a busload of other useful tricks.
```