### PR TITLE
Mount cdrom as RO to avoid device busy on fc40

### DIFF
--- a/ks.tpl.cfg
+++ b/ks.tpl.cfg
@@ -172,7 +172,7 @@ cd /tmp/installer
 if [ -b /dev/cdrom ]
 then
   mkdir -v /mnt/cdrom
-  mount -v /dev/cdrom /mnt/cdrom
+  mount -v -o ro /dev/cdrom /mnt/cdrom
   tar vxzf /mnt/cdrom/custom-files.tar.gz
   umount -v /mnt/cdrom
   rm -vrf /mnt/cdrom


### PR DESCRIPTION
CD-ROM device is still mounted outside chroot when running `%post` script on fc40 anaconda.