### PR TITLE
Read kernel command-line parameters from rootfs

### DIFF
--- a/root/etc/grub.d/10_linux
+++ b/root/etc/grub.d/10_linux
@@ -14,8 +14,8 @@ for uuid in ${GRUB_DISK_UUID0:-} ${GRUB_DISK_UUID1:-}; do
     cat <<EOS
 menuentry "tmpfsroot-fedora ${uuid}" {
   search --no-floppy --fs-uuid --set root ${uuid}
-  if [ -f \${root}/boot/grub-opts ]; then
-    source \${root}/boot/grub-opts
+  if [ -f (\${root})/boot/grub-opts ]; then
+    source (\${root})/boot/grub-opts
   fi
   linux /boot/vmlinuz root=UUID=${uuid} ro ${GRUB_CMDLINE_LINUX} ${GRUB_CMDLINE_LINUX_DEFAULT} \${GRUB_CMDLINE_LINUX_TMPFSROOT}
   initrd /boot/initramfs.img


### PR DESCRIPTION
Make it possible to set kernel command-line parameters specified in the selected rootfs