### PR TITLE
Detect timezone via /etc/timezone with /etc/localtime fallback

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ else
 FEDORA_RELEASE_DIR := $(FEDORA_MAJOR)
 endif
 
-ifeq ($(shell cat /etc/timezone),Asia/Tokyo)
+ifeq ($(shell timedatectl show -p Timezone --value 2>/dev/null),Asia/Tokyo)
 BUILD_OPTS := --build-arg FEDORA_ISO_MIRROR=https://ftp.yz.yamagata-u.ac.jp/pub/linux/fedora-projects/fedora/linux
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,8 @@ else
 FEDORA_RELEASE_DIR := $(FEDORA_MAJOR)
 endif
 
-ifeq ($(shell timedatectl show -p Timezone --value 2>/dev/null),Asia/Tokyo)
+TIMEZONE := $(shell cat /etc/timezone 2>/dev/null || readlink -f /etc/localtime 2>/dev/null | sed 's|.*/zoneinfo/||')
+ifeq ($(TIMEZONE),Asia/Tokyo)
 BUILD_OPTS := --build-arg FEDORA_ISO_MIRROR=https://ftp.yz.yamagata-u.ac.jp/pub/linux/fedora-projects/fedora/linux
 endif
 


### PR DESCRIPTION
The Makefile previously read /etc/timezone to decide whether to use the
Japanese Fedora mirror. That file is not present on all systems (notably
many systemd-based distros that only manage the timezone via timedatectl),
so the check would silently fail.

Read /etc/timezone first, falling back to resolving the /etc/localtime symlink when it is absent. 
