### PR TITLE
Bake base passwd/group into the ISO instead of running dnf in pre-install

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -135,6 +135,19 @@ while read rpm; do
   cp ./downloads/${rpm}.*.rpm iso-root/Packages/${initial}/
 done <rpms.lock
 
+# Bake base passwd/group into the ISO
+setup_rpm=$(ls iso-root/Packages/s/setup-*.rpm 2>/dev/null | head -n1)
+if [ -z "${setup_rpm}" ]; then
+  echo "setup package not found in iso-root/Packages" >&2
+  exit 1
+fi
+rm -rf setup-base
+mkdir -p setup-base
+(cd setup-base && rpm2cpio "../${setup_rpm}" | cpio -idmu --quiet ./etc/passwd ./etc/group)
+cp setup-base/etc/passwd iso-root/etc-passwd-base
+cp setup-base/etc/group iso-root/etc-group-base
+rm -rf setup-base
+
 # Create custom install files tarball
 cp -ar root.override/* root/ || true
 tar czf iso-root/custom-files.tar.gz root hooks.d

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -136,17 +136,18 @@ while read rpm; do
 done <rpms.lock
 
 # Bake base passwd/group into the ISO
-setup_rpm=$(ls iso-root/Packages/s/setup-*.rpm 2>/dev/null | head -n1)
-if [ -z "${setup_rpm}" ]; then
-  echo "setup package not found in iso-root/Packages" >&2
+shopt -s nullglob
+setup_rpms=(iso-root/Packages/s/setup-*.rpm)
+shopt -u nullglob
+if [ ${#setup_rpms[@]} -ne 1 ]; then
+  echo "expected exactly one setup package in iso-root/Packages, found ${#setup_rpms[@]}" >&2
   exit 1
 fi
-rm -rf setup-base
-mkdir -p setup-base
-(cd setup-base && rpm2cpio "../${setup_rpm}" | cpio -idmu --quiet ./etc/passwd ./etc/group)
-cp setup-base/etc/passwd iso-root/etc-passwd-base
-cp setup-base/etc/group iso-root/etc-group-base
-rm -rf setup-base
+setup_dir=$(mktemp -d)
+rpm2cpio "${setup_rpms[0]}" | (cd "${setup_dir}" && cpio -idmu --quiet ./etc/passwd ./etc/group)
+cp "${setup_dir}/etc/passwd" iso-root/etc-passwd-base
+cp "${setup_dir}/etc/group" iso-root/etc-group-base
+rm -rf "${setup_dir}"
 
 # Create custom install files tarball
 cp -ar root.override/* root/ || true

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -144,10 +144,10 @@ if [ ${#setup_rpms[@]} -ne 1 ]; then
   exit 1
 fi
 setup_dir=$(mktemp -d)
+trap 'rm -rf "${setup_dir}"' EXIT
 rpm2cpio "${setup_rpms[0]}" | (cd "${setup_dir}" && cpio -idmu --quiet ./etc/passwd ./etc/group)
 cp "${setup_dir}/etc/passwd" iso-root/etc-passwd-base
 cp "${setup_dir}/etc/group" iso-root/etc-group-base
-rm -rf "${setup_dir}"
 
 # Create custom install files tarball
 cp -ar root.override/* root/ || true

--- a/ks.tpl.cfg
+++ b/ks.tpl.cfg
@@ -106,6 +106,7 @@ set +e
   if [ -b /dev/cdrom ]
   then
     umount -v /dev/cdrom
+    rm -vrf /mnt/cdrom
   fi
 
 @@KS.PRE-INSTALL.CFG@@

--- a/ks.tpl.cfg
+++ b/ks.tpl.cfg
@@ -78,37 +78,23 @@ set +e
   fi
 
   # Make specified UID/GID static
-  mkdir -vp /tmp/setup
+  mkdir -vp /tmp/setup/etc
 
   if [ -b /dev/cdrom ]
   then
     mkdir -v /mnt/cdrom
     mount -v /dev/cdrom /mnt/cdrom
-    repo=/mnt/cdrom/
 
-    cp -v /mnt/cdrom/etc-passwd /mnt/cdrom/etc-group /tmp/setup/
+    cp -v /mnt/cdrom/etc-passwd-base /tmp/setup/etc/passwd
+    cp -v /mnt/cdrom/etc-group-base /tmp/setup/etc/group
+    cat /mnt/cdrom/etc-passwd >> /tmp/setup/etc/passwd
+    cat /mnt/cdrom/etc-group >> /tmp/setup/etc/group
   else
-    repo=http://172.16.250.1/iso/
-
-    curl http://172.16.250.1/iso/etc-passwd -o /tmp/setup/etc-passwd
-    curl http://172.16.250.1/iso/etc-group -o /tmp/setup/etc-group
+    curl http://172.16.250.1/iso/etc-passwd-base -o /tmp/setup/etc/passwd
+    curl http://172.16.250.1/iso/etc-group-base -o /tmp/setup/etc/group
+    curl http://172.16.250.1/iso/etc-passwd >> /tmp/setup/etc/passwd
+    curl http://172.16.250.1/iso/etc-group >> /tmp/setup/etc/group
   fi
-
-  (
-    # Extract base passwd/group from setup-*.rpm
-    . /etc/os-release
-    dnf install \
-      -y \
-      --nogpgcheck \
-      --installroot=/tmp/setup \
-      --releasever=${VERSION_ID} \
-      --repofrompath=installer,${repo} \
-      --repo=installer \
-      setup
-  )
-
-  cat /tmp/setup/etc-passwd >> /tmp/setup/etc/passwd
-  cat /tmp/setup/etc-group >> /tmp/setup/etc/group
 
   mkdir -vp /mnt/sysimage/etc
   chmod -v 755 /mnt/sysimage/etc

--- a/ks.tpl.cfg
+++ b/ks.tpl.cfg
@@ -82,7 +82,7 @@ set +e
 
   if [ -b /dev/cdrom ]
   then
-    mkdir -v /mnt/cdrom
+    mkdir -vp /mnt/cdrom
     mount -v /dev/cdrom /mnt/cdrom
 
     cp -v /mnt/cdrom/etc-passwd-base /tmp/setup/etc/passwd

--- a/ks.tpl.cfg
+++ b/ks.tpl.cfg
@@ -90,10 +90,10 @@ set +e
     cat /mnt/cdrom/etc-passwd >> /tmp/setup/etc/passwd
     cat /mnt/cdrom/etc-group >> /tmp/setup/etc/group
   else
-    curl http://172.16.250.1/iso/etc-passwd-base -o /tmp/setup/etc/passwd
-    curl http://172.16.250.1/iso/etc-group-base -o /tmp/setup/etc/group
-    curl http://172.16.250.1/iso/etc-passwd >> /tmp/setup/etc/passwd
-    curl http://172.16.250.1/iso/etc-group >> /tmp/setup/etc/group
+    curl -fsS http://172.16.250.1/iso/etc-passwd-base -o /tmp/setup/etc/passwd
+    curl -fsS http://172.16.250.1/iso/etc-group-base -o /tmp/setup/etc/group
+    curl -fsS http://172.16.250.1/iso/etc-passwd >> /tmp/setup/etc/passwd
+    curl -fsS http://172.16.250.1/iso/etc-group >> /tmp/setup/etc/group
   fi
 
   mkdir -vp /mnt/sysimage/etc


### PR DESCRIPTION
The Fedora >= 42 installer environment ships no `dnf` CLI (only
`dnf-3`/`dnf4`), so the kickstart's `dnf install setup` — used to get the
base passwd/group — fails with `command not found`.

This moves the extraction to build time:
- `entrypoint.sh` pulls `etc/passwd` and `etc/group` from the `setup` RPM
  and bakes them into the ISO as `etc-passwd-base`/`etc-group-base`.
- `%pre-install` just copies them and appends our static UID/GID entries.
